### PR TITLE
Resolve [Feature] Use thread instead of timer

### DIFF
--- a/TheEvolution/Core/GameSystem.cs
+++ b/TheEvolution/Core/GameSystem.cs
@@ -3,16 +3,21 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Windows.Forms;
 using System.Drawing;
+using TheEvolution.StageCell.Cells;
 
 namespace TheEvolution.Core {
     static class GameSystem {
-        public static int gameTime;
         public static Form currentForm;
+        public static PlayerCell currentPlayer;
 
-        public static void Act(object sender, EventArgs e) {
-            gameTime++;
+        public static void Act() {
+            while (true) {
+                currentPlayer.NextStep();
+                Thread.Sleep(100);
+            }
         }
 
         public static void setControlSize(Control control, Size ClientSize, double ratioL, double ratioT, double ratioW, double ratioH) {

--- a/TheEvolution/FormCellStage.cs
+++ b/TheEvolution/FormCellStage.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Threading;
 using System.Windows.Forms;
 using TheEvolution.Core;
 using TheEvolution.StageCell.Cells;
@@ -13,25 +14,22 @@ using TheEvolution.StageCell.Cells;
 namespace TheEvolution {
     public partial class FormCellStage : Form {
         PlayerCell player;
+        Thread threadAct;
 
         public FormCellStage() {
             InitializeComponent();
             GameSystem.currentForm = this;
-            GameEngine.Tick += GameSystem.Act;
-            player = new PlayerCell();
-            KeyDown += new KeyEventHandler(player.PlayerKeyDown);
-            KeyUp += new KeyEventHandler(player.PlayerKeyUp);
-            Paint += new PaintEventHandler(player.Paint);
-            GameEngine.Tick += new EventHandler(player.NextStep);
+            player = new PlayerCell(this);
+            threadAct = new Thread(GameSystem.Act);
         }
 
         private void FormCellStage_Load(object sender, EventArgs e) {
             GameSystem.setControlSize(labelExit, ClientSize, 0.04, 0.95, 0.05, 0.05);
-            GameSystem.setFrame(player, ClientSize, 0.5, 0.5, 0.08, 0.15);
-            GameEngine.Start();
+            threadAct.Start();
         }
 
         private void labelExit_Click(object sender, EventArgs e) {
+            threadAct.Abort();
             Application.Exit();
         }
     }


### PR DESCRIPTION
Resolve feature #17 

First use of thread, just a simple try.

Temporarily, do all repeated jobs in one thread called GameSystem Act.
Maybe some jobs should make a new thread independently in the future.

Also, I made player hook some methods inside its own constructor.
And so is player's frame and speed settings, not in a form's method,
as a result of being a player's method which will be called on a form's event.

Besides,
This is a example of #12